### PR TITLE
fix notify merge mining clean job

### DIFF
--- a/src/bitcoin/StratumServerBitcoin.cc
+++ b/src/bitcoin/StratumServerBitcoin.cc
@@ -114,7 +114,8 @@ void JobRepositoryBitcoin::broadcastStratumJob(
   // previous jobs don't have a sense and such shares will be rejected. When
   // this flag is set, miner should also drop all previous jobs.
   //
-  shared_ptr<StratumJobEx> exJob(createStratumJobEx(sjob, isClean));
+  shared_ptr<StratumJobEx> exJob(
+      createStratumJobEx(sjob, isClean || isMergedMiningClean));
 
   if (isClean) {
     // mark all jobs as stale, should do this before insert new job


### PR DESCRIPTION
fix #442 
构造并且notify一个clean job，其他逻辑保持不变(只在主链需要clean的时候才mark all local jobs stable)